### PR TITLE
refactor(NATE-069): ♻️ Refactor OpenAPI spec generation and route configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,5 @@
 !.nvmrc
 !.npmrc
 !package*.json
+!specs/
 !src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,9 +32,11 @@ services:
       test:
         - CMD-SHELL
         - >
-          node -e "require('http').get('http://localhost:3000/health',
-          res => process.exit(res.statusCode === 200 ? 0 : 1)).on('error', () =>
-          process.exit(1))"
+          node -e "
+            require('http')
+              .get('http://localhost:3000/health', (res) => process.exit(res.statusCode === 200 ? 0 : 1))
+              .on('error', () => process.exit(1))
+          "
       interval: 1m
       retries: 2
       start_period: 5s

--- a/specs/v1/openapi.json
+++ b/specs/v1/openapi.json
@@ -1,10 +1,34 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "Hono Documentation",
-    "description": "Development documentation",
-    "version": "0.0.0"
+    "title": "Typescript Service Template",
+    "description": "\n🚀 An API for managing resources\n\n### Pagination\n\nAll endpoints that return a list of items support pagination via search parameters. \n\nThe following parameters are supported:\n\n- `page` - The page number to return. Note that the first page is `1`.\n- `pageSize` - The number of items to return per page\n\n#### Filtering\n\nMost filterable search parameters support the following operators:\n\n- `eq` - equal\n- `ne` - not equal\n- `gt` - greater than\n- `gte` - greater than or equal\n- `lt` - less than\n- `lte` - less than or equal\n- `in` - in\n- `nin` - not in\n- `search` - case insensitive search\n\n> [!NOTE] You can combine multiple operators in a single request.\n> For example `createdAt:gte=2023-01-01Z&createdAt:lt=2024-01-01Z`\n\n#### Sorting\n\nPaginated response allow sorting by multiple fields. \n\nFor example, to sort by `createdAt` descending and `name` ascending: `sort=-createdAt,name`\n\n> [!NOTE]\n> To sort a field in descending order, prefix it with a `-`\n",
+    "version": "v1"
   },
+  "servers": [
+    {
+      "description": "Local",
+      "url": "http://localhost:3000"
+    },
+    {
+      "description": "Testing",
+      "url": "https://testing.example.com"
+    },
+    {
+      "description": "Staging",
+      "url": "https://staging.example.com"
+    },
+    {
+      "description": "Production",
+      "url": "https://production.example.com"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Resources",
+      "description": "Manage resources"
+    }
+  ],
   "paths": {
     "/api/v1/resources": {
       "post": {
@@ -14,145 +38,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "createdAt": {
-                      "type": "string",
-                      "example": "1900-01-01T00:00:00.000Z",
-                      "format": "date-time"
-                    },
-                    "createdBy": {
-                      "oneOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "system": {
-                              "type": "string",
-                              "description": "The system that performed the action",
-                              "example": "SYSTEM"
-                            },
-                            "type": {
-                              "type": "string",
-                              "const": "SYSTEM",
-                              "title": "System",
-                              "example": "SYSTEM"
-                            }
-                          },
-                          "required": [
-                            "system",
-                            "type"
-                          ]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "email": {
-                              "type": "string",
-                              "format": "email",
-                              "description": "The user who performed the action",
-                              "title": "Email",
-                              "example": "em@il.com"
-                            },
-                            "gid": {
-                              "type": "string",
-                              "example": "999.00000000-0000-0000-0000-000000000000"
-                            },
-                            "type": {
-                              "type": "string",
-                              "const": "USER",
-                              "title": "User",
-                              "example": "USER"
-                            }
-                          },
-                          "required": [
-                            "gid",
-                            "type"
-                          ]
-                        }
-                      ]
-                    },
-                    "gid": {
-                      "type": "string",
-                      "minLength": 1,
-                      "example": "999.00000000-0000-0000-0000-000000000000",
-                      "description": "The unique identifier for the resource"
-                    },
-                    "updatedAt": {
-                      "type": "string",
-                      "example": "1900-01-01T00:00:00.000Z",
-                      "format": "date-time"
-                    },
-                    "updatedBy": {
-                      "oneOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "system": {
-                              "type": "string",
-                              "description": "The system that performed the action",
-                              "example": "SYSTEM"
-                            },
-                            "type": {
-                              "type": "string",
-                              "const": "SYSTEM",
-                              "title": "System",
-                              "example": "SYSTEM"
-                            }
-                          },
-                          "required": [
-                            "system",
-                            "type"
-                          ]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "email": {
-                              "type": "string",
-                              "format": "email",
-                              "description": "The user who performed the action",
-                              "title": "Email",
-                              "example": "em@il.com"
-                            },
-                            "gid": {
-                              "type": "string",
-                              "example": "999.00000000-0000-0000-0000-000000000000"
-                            },
-                            "type": {
-                              "type": "string",
-                              "const": "USER",
-                              "title": "User",
-                              "example": "USER"
-                            }
-                          },
-                          "required": [
-                            "gid",
-                            "type"
-                          ]
-                        }
-                      ]
-                    },
-                    "name": {
-                      "type": "string",
-                      "minLength": 1,
-                      "description": "The name of the resource",
-                      "example": "Jane Doe"
-                    },
-                    "timeZone": {
-                      "type": "string",
-                      "description": "The time zone of the resource",
-                      "example": "America/New_York"
-                    }
-                  },
-                  "required": [
-                    "createdAt",
-                    "createdBy",
-                    "gid",
-                    "updatedAt",
-                    "updatedBy",
-                    "name",
-                    "timeZone"
-                  ]
+                  "$ref": "#/components/schemas/Resource"
                 }
               }
             }
@@ -196,52 +82,19 @@
                   "createdBy": {
                     "oneOf": [
                       {
-                        "type": "object",
-                        "properties": {
-                          "system": {
-                            "type": "string",
-                            "description": "The system that performed the action",
-                            "example": "SYSTEM"
-                          },
-                          "type": {
-                            "type": "string",
-                            "const": "SYSTEM",
-                            "title": "System",
-                            "example": "SYSTEM"
-                          }
-                        },
-                        "required": [
-                          "system",
-                          "type"
-                        ]
+                        "$ref": "#/components/schemas/AuditRecordSystem"
                       },
                       {
-                        "type": "object",
-                        "properties": {
-                          "email": {
-                            "type": "string",
-                            "format": "email",
-                            "description": "The user who performed the action",
-                            "title": "Email",
-                            "example": "em@il.com"
-                          },
-                          "gid": {
-                            "type": "string",
-                            "example": "999.00000000-0000-0000-0000-000000000000"
-                          },
-                          "type": {
-                            "type": "string",
-                            "const": "USER",
-                            "title": "User",
-                            "example": "USER"
-                          }
-                        },
-                        "required": [
-                          "gid",
-                          "type"
-                        ]
+                        "$ref": "#/components/schemas/AuditRecordUser"
                       }
-                    ]
+                    ],
+                    "discriminator": {
+                      "propertyName": "type",
+                      "mapping": {
+                        "SYSTEM": "#/components/schemas/AuditRecordSystem",
+                        "USER": "#/components/schemas/AuditRecordUser"
+                      }
+                    }
                   },
                   "name": {
                     "type": "string",
@@ -259,7 +112,74 @@
                   "createdBy",
                   "name",
                   "timeZone"
-                ]
+                ],
+                "description": "A resource entity",
+                "example": {
+                  "gid": "999.00000000-0000-0000-0000-000000000000",
+                  "name": "Jane Doe",
+                  "timeZone": "America/New_York",
+                  "createdAt": "1900-01-01T00:00:00.000Z",
+                  "createdBy": {
+                    "email": "em@il.com",
+                    "gid": "999.00000000-0000-0000-0000-000000000000",
+                    "type": "USER"
+                  },
+                  "updatedAt": "1900-01-01T00:00:00.000Z",
+                  "updatedBy": {
+                    "system": "SYSTEM",
+                    "type": "SYSTEM"
+                  }
+                }
+              },
+              "components": {
+                "AuditRecordSystem": {
+                  "type": "object",
+                  "properties": {
+                    "system": {
+                      "type": "string",
+                      "description": "The system that performed the action",
+                      "example": "SYSTEM"
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "SYSTEM",
+                      "title": "System",
+                      "example": "SYSTEM"
+                    }
+                  },
+                  "required": [
+                    "system",
+                    "type"
+                  ],
+                  "description": "A system that performed the action"
+                },
+                "AuditRecordUser": {
+                  "type": "object",
+                  "properties": {
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "description": "The email of the user who performed the action",
+                      "title": "Email",
+                      "example": "em@il.com"
+                    },
+                    "gid": {
+                      "type": "string",
+                      "example": "999.00000000-0000-0000-0000-000000000000"
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "USER",
+                      "title": "User",
+                      "example": "USER"
+                    }
+                  },
+                  "required": [
+                    "gid",
+                    "type"
+                  ],
+                  "description": "A user who performed the action"
+                }
               }
             }
           }
@@ -306,145 +226,7 @@
                     "items": {
                       "type": "array",
                       "items": {
-                        "type": "object",
-                        "properties": {
-                          "createdAt": {
-                            "type": "string",
-                            "example": "1900-01-01T00:00:00.000Z",
-                            "format": "date-time"
-                          },
-                          "createdBy": {
-                            "oneOf": [
-                              {
-                                "type": "object",
-                                "properties": {
-                                  "system": {
-                                    "type": "string",
-                                    "description": "The system that performed the action",
-                                    "example": "SYSTEM"
-                                  },
-                                  "type": {
-                                    "type": "string",
-                                    "const": "SYSTEM",
-                                    "title": "System",
-                                    "example": "SYSTEM"
-                                  }
-                                },
-                                "required": [
-                                  "system",
-                                  "type"
-                                ]
-                              },
-                              {
-                                "type": "object",
-                                "properties": {
-                                  "email": {
-                                    "type": "string",
-                                    "format": "email",
-                                    "description": "The user who performed the action",
-                                    "title": "Email",
-                                    "example": "em@il.com"
-                                  },
-                                  "gid": {
-                                    "type": "string",
-                                    "example": "999.00000000-0000-0000-0000-000000000000"
-                                  },
-                                  "type": {
-                                    "type": "string",
-                                    "const": "USER",
-                                    "title": "User",
-                                    "example": "USER"
-                                  }
-                                },
-                                "required": [
-                                  "gid",
-                                  "type"
-                                ]
-                              }
-                            ]
-                          },
-                          "gid": {
-                            "type": "string",
-                            "minLength": 1,
-                            "example": "999.00000000-0000-0000-0000-000000000000",
-                            "description": "The unique identifier for the resource"
-                          },
-                          "updatedAt": {
-                            "type": "string",
-                            "example": "1900-01-01T00:00:00.000Z",
-                            "format": "date-time"
-                          },
-                          "updatedBy": {
-                            "oneOf": [
-                              {
-                                "type": "object",
-                                "properties": {
-                                  "system": {
-                                    "type": "string",
-                                    "description": "The system that performed the action",
-                                    "example": "SYSTEM"
-                                  },
-                                  "type": {
-                                    "type": "string",
-                                    "const": "SYSTEM",
-                                    "title": "System",
-                                    "example": "SYSTEM"
-                                  }
-                                },
-                                "required": [
-                                  "system",
-                                  "type"
-                                ]
-                              },
-                              {
-                                "type": "object",
-                                "properties": {
-                                  "email": {
-                                    "type": "string",
-                                    "format": "email",
-                                    "description": "The user who performed the action",
-                                    "title": "Email",
-                                    "example": "em@il.com"
-                                  },
-                                  "gid": {
-                                    "type": "string",
-                                    "example": "999.00000000-0000-0000-0000-000000000000"
-                                  },
-                                  "type": {
-                                    "type": "string",
-                                    "const": "USER",
-                                    "title": "User",
-                                    "example": "USER"
-                                  }
-                                },
-                                "required": [
-                                  "gid",
-                                  "type"
-                                ]
-                              }
-                            ]
-                          },
-                          "name": {
-                            "type": "string",
-                            "minLength": 1,
-                            "description": "The name of the resource",
-                            "example": "Jane Doe"
-                          },
-                          "timeZone": {
-                            "type": "string",
-                            "description": "The time zone of the resource",
-                            "example": "America/New_York"
-                          }
-                        },
-                        "required": [
-                          "createdAt",
-                          "createdBy",
-                          "gid",
-                          "updatedAt",
-                          "updatedBy",
-                          "name",
-                          "timeZone"
-                        ]
+                        "$ref": "#/components/schemas/Resource"
                       }
                     }
                   },
@@ -602,145 +384,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "createdAt": {
-                      "type": "string",
-                      "example": "1900-01-01T00:00:00.000Z",
-                      "format": "date-time"
-                    },
-                    "createdBy": {
-                      "oneOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "system": {
-                              "type": "string",
-                              "description": "The system that performed the action",
-                              "example": "SYSTEM"
-                            },
-                            "type": {
-                              "type": "string",
-                              "const": "SYSTEM",
-                              "title": "System",
-                              "example": "SYSTEM"
-                            }
-                          },
-                          "required": [
-                            "system",
-                            "type"
-                          ]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "email": {
-                              "type": "string",
-                              "format": "email",
-                              "description": "The user who performed the action",
-                              "title": "Email",
-                              "example": "em@il.com"
-                            },
-                            "gid": {
-                              "type": "string",
-                              "example": "999.00000000-0000-0000-0000-000000000000"
-                            },
-                            "type": {
-                              "type": "string",
-                              "const": "USER",
-                              "title": "User",
-                              "example": "USER"
-                            }
-                          },
-                          "required": [
-                            "gid",
-                            "type"
-                          ]
-                        }
-                      ]
-                    },
-                    "gid": {
-                      "type": "string",
-                      "minLength": 1,
-                      "example": "999.00000000-0000-0000-0000-000000000000",
-                      "description": "The unique identifier for the resource"
-                    },
-                    "updatedAt": {
-                      "type": "string",
-                      "example": "1900-01-01T00:00:00.000Z",
-                      "format": "date-time"
-                    },
-                    "updatedBy": {
-                      "oneOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "system": {
-                              "type": "string",
-                              "description": "The system that performed the action",
-                              "example": "SYSTEM"
-                            },
-                            "type": {
-                              "type": "string",
-                              "const": "SYSTEM",
-                              "title": "System",
-                              "example": "SYSTEM"
-                            }
-                          },
-                          "required": [
-                            "system",
-                            "type"
-                          ]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "email": {
-                              "type": "string",
-                              "format": "email",
-                              "description": "The user who performed the action",
-                              "title": "Email",
-                              "example": "em@il.com"
-                            },
-                            "gid": {
-                              "type": "string",
-                              "example": "999.00000000-0000-0000-0000-000000000000"
-                            },
-                            "type": {
-                              "type": "string",
-                              "const": "USER",
-                              "title": "User",
-                              "example": "USER"
-                            }
-                          },
-                          "required": [
-                            "gid",
-                            "type"
-                          ]
-                        }
-                      ]
-                    },
-                    "name": {
-                      "type": "string",
-                      "minLength": 1,
-                      "description": "The name of the resource",
-                      "example": "Jane Doe"
-                    },
-                    "timeZone": {
-                      "type": "string",
-                      "description": "The time zone of the resource",
-                      "example": "America/New_York"
-                    }
-                  },
-                  "required": [
-                    "createdAt",
-                    "createdBy",
-                    "gid",
-                    "updatedAt",
-                    "updatedBy",
-                    "name",
-                    "timeZone"
-                  ]
+                  "$ref": "#/components/schemas/Resource"
                 }
               }
             }
@@ -793,145 +437,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "createdAt": {
-                      "type": "string",
-                      "example": "1900-01-01T00:00:00.000Z",
-                      "format": "date-time"
-                    },
-                    "createdBy": {
-                      "oneOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "system": {
-                              "type": "string",
-                              "description": "The system that performed the action",
-                              "example": "SYSTEM"
-                            },
-                            "type": {
-                              "type": "string",
-                              "const": "SYSTEM",
-                              "title": "System",
-                              "example": "SYSTEM"
-                            }
-                          },
-                          "required": [
-                            "system",
-                            "type"
-                          ]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "email": {
-                              "type": "string",
-                              "format": "email",
-                              "description": "The user who performed the action",
-                              "title": "Email",
-                              "example": "em@il.com"
-                            },
-                            "gid": {
-                              "type": "string",
-                              "example": "999.00000000-0000-0000-0000-000000000000"
-                            },
-                            "type": {
-                              "type": "string",
-                              "const": "USER",
-                              "title": "User",
-                              "example": "USER"
-                            }
-                          },
-                          "required": [
-                            "gid",
-                            "type"
-                          ]
-                        }
-                      ]
-                    },
-                    "gid": {
-                      "type": "string",
-                      "minLength": 1,
-                      "example": "999.00000000-0000-0000-0000-000000000000",
-                      "description": "The unique identifier for the resource"
-                    },
-                    "updatedAt": {
-                      "type": "string",
-                      "example": "1900-01-01T00:00:00.000Z",
-                      "format": "date-time"
-                    },
-                    "updatedBy": {
-                      "oneOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "system": {
-                              "type": "string",
-                              "description": "The system that performed the action",
-                              "example": "SYSTEM"
-                            },
-                            "type": {
-                              "type": "string",
-                              "const": "SYSTEM",
-                              "title": "System",
-                              "example": "SYSTEM"
-                            }
-                          },
-                          "required": [
-                            "system",
-                            "type"
-                          ]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "email": {
-                              "type": "string",
-                              "format": "email",
-                              "description": "The user who performed the action",
-                              "title": "Email",
-                              "example": "em@il.com"
-                            },
-                            "gid": {
-                              "type": "string",
-                              "example": "999.00000000-0000-0000-0000-000000000000"
-                            },
-                            "type": {
-                              "type": "string",
-                              "const": "USER",
-                              "title": "User",
-                              "example": "USER"
-                            }
-                          },
-                          "required": [
-                            "gid",
-                            "type"
-                          ]
-                        }
-                      ]
-                    },
-                    "name": {
-                      "type": "string",
-                      "minLength": 1,
-                      "description": "The name of the resource",
-                      "example": "Jane Doe"
-                    },
-                    "timeZone": {
-                      "type": "string",
-                      "description": "The time zone of the resource",
-                      "example": "America/New_York"
-                    }
-                  },
-                  "required": [
-                    "createdAt",
-                    "createdBy",
-                    "gid",
-                    "updatedAt",
-                    "updatedBy",
-                    "name",
-                    "timeZone"
-                  ]
+                  "$ref": "#/components/schemas/Resource"
                 }
               }
             }
@@ -993,57 +499,91 @@
                   "updatedBy": {
                     "oneOf": [
                       {
-                        "type": "object",
-                        "properties": {
-                          "system": {
-                            "type": "string",
-                            "description": "The system that performed the action",
-                            "example": "SYSTEM"
-                          },
-                          "type": {
-                            "type": "string",
-                            "const": "SYSTEM",
-                            "title": "System",
-                            "example": "SYSTEM"
-                          }
-                        },
-                        "required": [
-                          "system",
-                          "type"
-                        ]
+                        "$ref": "#/components/schemas/AuditRecordSystem"
                       },
                       {
-                        "type": "object",
-                        "properties": {
-                          "email": {
-                            "type": "string",
-                            "format": "email",
-                            "description": "The user who performed the action",
-                            "title": "Email",
-                            "example": "em@il.com"
-                          },
-                          "gid": {
-                            "type": "string",
-                            "example": "999.00000000-0000-0000-0000-000000000000"
-                          },
-                          "type": {
-                            "type": "string",
-                            "const": "USER",
-                            "title": "User",
-                            "example": "USER"
-                          }
-                        },
-                        "required": [
-                          "gid",
-                          "type"
-                        ]
+                        "$ref": "#/components/schemas/AuditRecordUser"
                       }
-                    ]
+                    ],
+                    "discriminator": {
+                      "propertyName": "type",
+                      "mapping": {
+                        "SYSTEM": "#/components/schemas/AuditRecordSystem",
+                        "USER": "#/components/schemas/AuditRecordUser"
+                      }
+                    }
                   }
                 },
                 "required": [
                   "updatedBy"
-                ]
+                ],
+                "description": "A resource entity",
+                "example": {
+                  "gid": "999.00000000-0000-0000-0000-000000000000",
+                  "name": "Jane Doe",
+                  "timeZone": "America/New_York",
+                  "createdAt": "1900-01-01T00:00:00.000Z",
+                  "createdBy": {
+                    "email": "em@il.com",
+                    "gid": "999.00000000-0000-0000-0000-000000000000",
+                    "type": "USER"
+                  },
+                  "updatedAt": "1900-01-01T00:00:00.000Z",
+                  "updatedBy": {
+                    "system": "SYSTEM",
+                    "type": "SYSTEM"
+                  }
+                }
+              },
+              "components": {
+                "AuditRecordSystem": {
+                  "type": "object",
+                  "properties": {
+                    "system": {
+                      "type": "string",
+                      "description": "The system that performed the action",
+                      "example": "SYSTEM"
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "SYSTEM",
+                      "title": "System",
+                      "example": "SYSTEM"
+                    }
+                  },
+                  "required": [
+                    "system",
+                    "type"
+                  ],
+                  "description": "A system that performed the action"
+                },
+                "AuditRecordUser": {
+                  "type": "object",
+                  "properties": {
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "description": "The email of the user who performed the action",
+                      "title": "Email",
+                      "example": "em@il.com"
+                    },
+                    "gid": {
+                      "type": "string",
+                      "example": "999.00000000-0000-0000-0000-000000000000"
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "USER",
+                      "title": "User",
+                      "example": "USER"
+                    }
+                  },
+                  "required": [
+                    "gid",
+                    "type"
+                  ],
+                  "description": "A user who performed the action"
+                }
               }
             }
           }
@@ -1052,6 +592,147 @@
     }
   },
   "components": {
-    "schemas": {}
+    "schemas": {
+      "Resource": {
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "example": "1900-01-01T00:00:00.000Z",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuditRecordSystem"
+              },
+              {
+                "$ref": "#/components/schemas/AuditRecordUser"
+              }
+            ],
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "SYSTEM": "#/components/schemas/AuditRecordSystem",
+                "USER": "#/components/schemas/AuditRecordUser"
+              }
+            }
+          },
+          "gid": {
+            "type": "string",
+            "minLength": 1,
+            "example": "999.00000000-0000-0000-0000-000000000000",
+            "description": "The unique identifier for the resource"
+          },
+          "updatedAt": {
+            "type": "string",
+            "example": "1900-01-01T00:00:00.000Z",
+            "format": "date-time"
+          },
+          "updatedBy": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AuditRecordSystem"
+              },
+              {
+                "$ref": "#/components/schemas/AuditRecordUser"
+              }
+            ],
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "SYSTEM": "#/components/schemas/AuditRecordSystem",
+                "USER": "#/components/schemas/AuditRecordUser"
+              }
+            }
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the resource",
+            "example": "Jane Doe"
+          },
+          "timeZone": {
+            "type": "string",
+            "description": "The time zone of the resource",
+            "example": "America/New_York"
+          }
+        },
+        "required": [
+          "createdAt",
+          "createdBy",
+          "gid",
+          "updatedAt",
+          "updatedBy",
+          "name",
+          "timeZone"
+        ],
+        "description": "A resource entity",
+        "example": {
+          "gid": "999.00000000-0000-0000-0000-000000000000",
+          "name": "Jane Doe",
+          "timeZone": "America/New_York",
+          "createdAt": "1900-01-01T00:00:00.000Z",
+          "createdBy": {
+            "email": "em@il.com",
+            "gid": "999.00000000-0000-0000-0000-000000000000",
+            "type": "USER"
+          },
+          "updatedAt": "1900-01-01T00:00:00.000Z",
+          "updatedBy": {
+            "system": "SYSTEM",
+            "type": "SYSTEM"
+          }
+        }
+      },
+      "AuditRecordSystem": {
+        "type": "object",
+        "properties": {
+          "system": {
+            "type": "string",
+            "description": "The system that performed the action",
+            "example": "SYSTEM"
+          },
+          "type": {
+            "type": "string",
+            "const": "SYSTEM",
+            "title": "System",
+            "example": "SYSTEM"
+          }
+        },
+        "required": [
+          "system",
+          "type"
+        ],
+        "description": "A system that performed the action"
+      },
+      "AuditRecordUser": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "The email of the user who performed the action",
+            "title": "Email",
+            "example": "em@il.com"
+          },
+          "gid": {
+            "type": "string",
+            "example": "999.00000000-0000-0000-0000-000000000000"
+          },
+          "type": {
+            "type": "string",
+            "const": "USER",
+            "title": "User",
+            "example": "USER"
+          }
+        },
+        "required": [
+          "gid",
+          "type"
+        ],
+        "description": "A user who performed the action"
+      }
+    }
   }
 }

--- a/src/api/generate-all-openapi-specs.test.ts
+++ b/src/api/generate-all-openapi-specs.test.ts
@@ -1,3 +1,4 @@
+import * as Fs from 'node:fs'
 import { Hono } from 'hono'
 import { generateAllSpecs } from './generate-all-openapi-specs.ts'
 import type { Env } from './http/v1/models.ts'
@@ -5,6 +6,7 @@ import type { Env } from './http/v1/models.ts'
 vi.mock('node:fs', () => ({
   existsSync: vi.fn().mockReturnValue(true),
   mkdirSync: vi.fn().mockReturnValue(undefined),
+  readFileSync: vi.fn().mockReturnValue(undefined),
   writeFileSync: vi.fn().mockReturnValue(undefined),
 }))
 
@@ -22,21 +24,71 @@ describe('generateAllSpecs', () => {
       vi.stubEnv('GENERATE_OPENAPI_SPEC', 'true')
     })
 
-    test('should generate an openapi spec', async () => {
-      const app = new Hono<Env>()
+    describe('when the spec does not previously exist', () => {
+      beforeEach(() => {
+        vi.spyOn(Fs, 'existsSync').mockReturnValueOnce(false).mockRejectedValueOnce(false)
+        vi.spyOn(Fs, 'readFileSync').mockReturnValue('')
+      })
 
-      await generateAllSpecs(app)
+      test('should generate an openapi spec', async () => {
+        const app = new Hono<Env>()
 
-      const fs = await import('node:fs')
+        await generateAllSpecs(app)
 
-      expect(fs.existsSync).toHaveBeenCalledWith(expect.stringMatching(/specs\/v1$/))
-      expect(fs.mkdirSync).toHaveBeenCalledWith(expect.stringMatching(/specs\/v1$/), { recursive: true })
+        const fs = await import('node:fs')
 
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
-        expect.stringMatching(/specs\/v1\/openapi.json$/),
-        undefined,
-        'utf8',
-      )
+        expect(fs.existsSync).toHaveBeenCalledWith(expect.stringMatching(/specs\/v1$/))
+        expect(fs.mkdirSync).toHaveBeenCalledWith(expect.stringMatching(/specs\/v1$/), { recursive: true })
+
+        expect(fs.writeFileSync).toHaveBeenCalledWith(
+          expect.stringMatching(/specs\/v1\/openapi.json$/),
+          undefined,
+          'utf8',
+        )
+      })
+    })
+
+    describe('when the spec has changed', () => {
+      beforeEach(() => {
+        vi.spyOn(Fs, 'existsSync').mockReturnValueOnce(false).mockRejectedValueOnce(true)
+        vi.spyOn(Fs, 'readFileSync').mockReturnValue('')
+      })
+
+      test('should generate an openapi spec', async () => {
+        const app = new Hono<Env>()
+
+        await generateAllSpecs(app)
+
+        const fs = await import('node:fs')
+
+        expect(fs.existsSync).toHaveBeenCalledWith(expect.stringMatching(/specs\/v1$/))
+        expect(fs.mkdirSync).toHaveBeenCalledWith(expect.stringMatching(/specs\/v1$/), { recursive: true })
+
+        expect(fs.writeFileSync).toHaveBeenCalledWith(
+          expect.stringMatching(/specs\/v1\/openapi.json$/),
+          undefined,
+          'utf8',
+        )
+      })
+    })
+
+    describe('when the spec has NOT changed', () => {
+      beforeEach(() => {
+        vi.spyOn(Fs, 'existsSync').mockReturnValueOnce(false).mockRejectedValueOnce(true)
+      })
+
+      test('should NOT write an openapi spec', async () => {
+        const app = new Hono<Env>()
+        const specs = await generateAllSpecs(app)
+
+        const fs = await import('node:fs')
+
+        vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
+          return specs[0] as string
+        })
+
+        expect(fs.writeFileSync).not.toHaveBeenCalled()
+      })
     })
   })
 

--- a/src/api/generate-all-openapi-specs.ts
+++ b/src/api/generate-all-openapi-specs.ts
@@ -1,10 +1,27 @@
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { generateSpecs } from 'hono-openapi'
 import { logger } from '../utils/logger.ts'
+import { OpenApiTag } from './http/models/openapi.ts'
 import type { makeApp } from './http/v1/app.ts'
-import { version } from './http/v1/models.ts'
+import { version as v1Version } from './http/v1/models.ts'
+import { copy } from './http/v1/openapi/copy.ts'
+
+const tagMap: Record<OpenApiTag, string> = {
+  [OpenApiTag.RESOURCES]: 'Manage resources',
+}
+
+const versions = [v1Version] as const
+const tags = Object.entries(tagMap).map(([name, description]) => ({ name, description }))
+
+const areSpecsEqual = (filePath: string, spec: string) => {
+  if (!existsSync(filePath)) {
+    return false
+  }
+
+  return readFileSync(filePath, { encoding: 'utf8' }) === spec
+}
 
 const makeGenerateOpenApiSpec = (app: ReturnType<typeof makeApp>) => async (version: string) => {
   const __filename = fileURLToPath(import.meta.url)
@@ -15,24 +32,65 @@ const makeGenerateOpenApiSpec = (app: ReturnType<typeof makeApp>) => async (vers
   }
 
   const openApiSpecPath = `${openApiSpecDirectory}/openapi.json`
-  const spec = await generateSpecs(app)
 
-  writeFileSync(openApiSpecPath, JSON.stringify(spec, null, 2), 'utf8')
+  const spec = await generateSpecs(app, {
+    documentation: {
+      info: {
+        title: 'Typescript Service Template',
+        version,
+        description: copy.introduction,
+      },
+      servers: [
+        // Update the URLs to match your environments
+        {
+          description: 'Local',
+          url: 'http://localhost:3000',
+        },
+        {
+          description: 'Testing',
+          url: 'https://testing.example.com',
+        },
+        {
+          description: 'Staging',
+          url: 'https://staging.example.com',
+        },
+        {
+          description: 'Production',
+          url: 'https://production.example.com',
+        },
+      ],
+      tags,
+    },
+  })
+
+  const stringifiedSpec = JSON.stringify(spec, null, 2)
+
+  if (areSpecsEqual(openApiSpecPath, stringifiedSpec)) {
+    logger.info(`📗 OpenAPI spec for version ${version} is up to date`)
+
+    return stringifiedSpec
+  }
+
+  writeFileSync(openApiSpecPath, stringifiedSpec, 'utf8')
+
+  return stringifiedSpec
 }
 
-const generateAllSpecs = (app: ReturnType<typeof makeApp>) => {
+const generateAllSpecs = async (app: ReturnType<typeof makeApp>) => {
   // biome-ignore lint/nursery/noProcessEnv: <explanation>
   if (!process.env.GENERATE_OPENAPI_SPEC) {
-    return
+    return []
   }
 
   logger.info('📘 Generating latest openapi spec(s)...')
 
-  const versions = [version]
   const generateOpenApiSpec = makeGenerateOpenApiSpec(app)
 
-  versions.map(generateOpenApiSpec)
+  const specs = await Promise.all(versions.map(generateOpenApiSpec))
+
   logger.info('✅ Latest openapi spec(s) generated successfully')
+
+  return specs
 }
 
 export { generateAllSpecs }

--- a/src/api/http/init.test.ts
+++ b/src/api/http/init.test.ts
@@ -28,7 +28,7 @@ describe('initHttp', () => {
   })
 
   it('should have registered all the expected routes', async () => {
-    const app = initHttp(dependencies)
+    const app = await initHttp(dependencies)
 
     expect(app.routes).toMatchInlineSnapshot(`
       [

--- a/src/api/http/init.ts
+++ b/src/api/http/init.ts
@@ -1,5 +1,6 @@
 import type { Domain } from '../../domain/init.ts'
 import type { AppStateManager } from '../../utils/app-state-manager.ts'
+import { generateAllSpecs } from '../generate-all-openapi-specs.ts'
 import { initCommon } from './common/init.ts'
 import { makeApp } from './v1/app.ts'
 import { initV1 } from './v1/init.ts'
@@ -9,11 +10,13 @@ type Dependencies = {
   domain: Domain
 }
 
-const initHttp = ({ appStateManager, domain }: Dependencies) => {
+const initHttp = async ({ appStateManager, domain }: Dependencies) => {
   const app = makeApp({ strict: false })
 
   app.route('/', initCommon({ appStateManager }))
   app.route('/', initV1({ app, domain }))
+
+  await generateAllSpecs(app)
 
   return app
 }

--- a/src/api/http/v1/init.ts
+++ b/src/api/http/v1/init.ts
@@ -17,11 +17,8 @@ const initV1 = (dependencies: Dependencies) => {
   initMiddleware(dependencies)
 
   app.route(`/api/${version}/resources`, resources)
-
-  // This must be the last to capture all the
-  // applied routes and models
   app.route(`/api/${version}/docs`, docs)
-  app.get(`/api/${version}/openapi`, openapi(app))
+  app.get(`/api/${version}/openapi`, openapi)
 
   return app
 }

--- a/src/api/http/v1/openapi/copy.ts
+++ b/src/api/http/v1/openapi/copy.ts
@@ -48,4 +48,9 @@ ${sortableFields
   .join('\n')}
 `
 
-export { introduction, sortable }
+const copy = {
+  introduction,
+  sortable,
+} as const
+
+export { copy }

--- a/src/api/http/v1/openapi/init.ts
+++ b/src/api/http/v1/openapi/init.ts
@@ -1,46 +1,6 @@
-import { openAPISpecs } from 'hono-openapi'
-import { OpenApiTag } from '../../models/openapi.ts'
-import { version } from '../models.ts'
-import { introduction } from './copy.ts'
+import type { Handler } from 'hono'
+import openapiSpec from '../../../../../specs/v1/openapi.json' with { type: 'json' }
 
-import 'zod-openapi/extend'
-import type { makeApp } from '../app.ts'
-
-const tagMap: Record<OpenApiTag, string> = {
-  [OpenApiTag.RESOURCES]: 'Manage resources',
-}
-
-const tags = Object.entries(tagMap).map(([name, description]) => ({ name, description }))
-
-const openapi = (app: ReturnType<typeof makeApp>) =>
-  openAPISpecs(app, {
-    documentation: {
-      info: {
-        title: 'Typescript Service Template',
-        version,
-        description: introduction,
-      },
-      servers: [
-        // Update the URLs to match your environments
-        {
-          description: 'Local',
-          url: 'http://localhost:3000',
-        },
-        {
-          description: 'Testing',
-          url: 'https://testing.example.com',
-        },
-        {
-          description: 'Staging',
-          url: 'https://staging.example.com',
-        },
-        {
-          description: 'Production',
-          url: 'https://production.example.com',
-        },
-      ],
-      tags,
-    },
-  })
+const openapi: Handler = (c) => c.json(openapiSpec)
 
 export { openapi }

--- a/src/api/http/v1/routes/resources.ts
+++ b/src/api/http/v1/routes/resources.ts
@@ -5,17 +5,17 @@ import { urlSearchParamsToPagination } from '../../../../utils/url-search-params
 import { urlSearchParamsToSort } from '../../../../utils/url-search-params/sorting.ts'
 import { OpenApiTag } from '../../models/openapi.ts'
 import { makeApp } from '../app.ts'
-import { RouteType, generateOpenApiRouteConfig } from '../openapi/generate-open-api-route-config.ts'
+import { RouteType, appendOpenApiMetadata } from '../openapi/append-open-api-metadata.ts'
 
 const resources = makeApp()
 
 resources.post(
   '/',
-  generateOpenApiRouteConfig({
+  appendOpenApiMetadata({
     operationId: 'resourcesCreateOne',
     requestSchema: ResourceService.schemas.request.createOne,
     schemaResponse: ResourceService.schemas.response.getOne,
-    tag: OpenApiTag.RESOURCES,
+    tags: [OpenApiTag.RESOURCES],
     type: RouteType.CREATE_ONE,
   }),
   async (ctx) => {
@@ -29,14 +29,14 @@ resources.post(
 
 resources.get(
   '/',
-  generateOpenApiRouteConfig({
+  appendOpenApiMetadata({
     defaultSortField: 'createdAt',
     filterableFields: ResourceService.filterableFields,
     operationId: 'resourcesGetMany',
     requestSchema: ResourceService.schemas.request.getMany,
     schemaResponse: ResourceService.schemas.response.getMany,
     sortableFields: ResourceService.sortableFields,
-    tag: OpenApiTag.RESOURCES,
+    tags: [OpenApiTag.RESOURCES],
     type: RouteType.GET_MANY,
   }),
   async (ctx) => {
@@ -57,10 +57,10 @@ resources.get(
 
 resources.get(
   '/:gid',
-  generateOpenApiRouteConfig({
+  appendOpenApiMetadata({
     operationId: 'resourcesGetOne',
     schemaResponse: ResourceService.schemas.response.getOne,
-    tag: OpenApiTag.RESOURCES,
+    tags: [OpenApiTag.RESOURCES],
     type: RouteType.GET_ONE,
   }),
   async (ctx) => {
@@ -74,11 +74,11 @@ resources.get(
 
 resources.patch(
   '/:gid',
-  generateOpenApiRouteConfig({
+  appendOpenApiMetadata({
     operationId: 'resourcesUpdateOne',
     requestSchema: ResourceService.schemas.request.updateOne,
     schemaResponse: ResourceService.schemas.response.getOne,
-    tag: OpenApiTag.RESOURCES,
+    tags: [OpenApiTag.RESOURCES],
     type: RouteType.UPDATE_ONE,
   }),
   async (ctx) => {

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -3,7 +3,6 @@ import type { Domain } from '../domain/init.ts'
 import type { AppStateManager, Closable } from '../utils/app-state-manager.ts'
 import { config } from '../utils/config.ts'
 import { logger } from '../utils/logger.ts'
-import { generateAllSpecs } from './generate-all-openapi-specs.ts'
 import { initHttp } from './http/init.ts'
 
 type Dependencies = {
@@ -15,10 +14,6 @@ const hostname = '0.0.0.0'
 
 const initApi = async (dependencies: Dependencies) => {
   const app = await initHttp(dependencies)
-
-  await generateAllSpecs(app)
-
-  const { appStateManager } = dependencies
 
   const options: Parameters<typeof serve>[0] = {
     fetch: app.fetch,
@@ -42,7 +37,7 @@ const initApi = async (dependencies: Dependencies) => {
     },
   }
 
-  appStateManager.registerClosableDependency(closeableServer)
+  dependencies.appStateManager.registerClosableDependency(closeableServer)
 
   return { server }
 }

--- a/src/domain/models/resource.ts
+++ b/src/domain/models/resource.ts
@@ -4,7 +4,9 @@ import { schemaEntity } from '../../models/entity.ts'
 import { exampleGid } from '../../utils/generators/gid.ts'
 import { validation } from '../../utils/validation.ts'
 
-const schemaResource = schemaEntity.extend({
+import 'zod-openapi/extend'
+
+const schemaResourceTemp = schemaEntity.extend({
   gid: validation.string.openapi({
     example: exampleGid(false),
     description: 'The unique identifier for the resource',
@@ -18,7 +20,7 @@ const schemaResource = schemaEntity.extend({
   }),
 })
 
-type Resource = Prettify<z.infer<typeof schemaResource>>
+type Resource = Prettify<z.infer<typeof schemaResourceTemp>>
 
 const exampleResource = (overrides: Partial<Resource> = {}): Resource => ({
   gid: exampleGid(false),
@@ -31,9 +33,10 @@ const exampleResource = (overrides: Partial<Resource> = {}): Resource => ({
   ...overrides,
 })
 
-schemaResource.openapi({
+const schemaResource = z.object(schemaResourceTemp.shape).openapi({
   description: 'A resource entity',
   example: exampleResource(),
+  ref: 'Resource',
 })
 
 export { exampleResource, schemaResource }

--- a/src/models/audit-record.ts
+++ b/src/models/audit-record.ts
@@ -1,15 +1,22 @@
 import { z } from 'zod'
 import { exampleGid } from '../utils/generators/gid.ts'
 
+import 'zod-openapi/extend'
+
 const AuditRecordType = {
   SYSTEM: 'SYSTEM',
   USER: 'USER',
 } as const
 
-const schemaAuditRecordSystem = z.object({
-  system: z.string().openapi({ description: 'The system that performed the action', example: 'SYSTEM' }),
-  type: z.literal(AuditRecordType.SYSTEM).openapi({ title: 'System', example: AuditRecordType.SYSTEM }),
-})
+const schemaAuditRecordSystem = z
+  .object({
+    system: z.string().openapi({ description: 'The system that performed the action', example: 'SYSTEM' }),
+    type: z.literal(AuditRecordType.SYSTEM).openapi({ title: 'System', example: AuditRecordType.SYSTEM }),
+  })
+  .openapi({
+    description: 'A system that performed the action',
+    ref: 'AuditRecordSystem',
+  })
 
 type AuditRecordSystem = Prettify<z.infer<typeof schemaAuditRecordSystem>>
 
@@ -19,15 +26,20 @@ const exampleAuditRecordSystem = (overrides: Partial<AuditRecordSystem> = {}): A
   ...overrides,
 })
 
-const schemaAuditRecordUser = z.object({
-  email: z
-    .string()
-    .email()
-    .optional()
-    .openapi({ description: 'The user who performed the action', title: 'Email', example: 'em@il.com' }),
-  gid: z.string().openapi({ example: exampleGid(false) }),
-  type: z.literal(AuditRecordType.USER).openapi({ title: 'User', example: AuditRecordType.USER }),
-})
+const schemaAuditRecordUser = z
+  .object({
+    email: z
+      .string()
+      .email()
+      .optional()
+      .openapi({ description: 'The email of the user who performed the action', title: 'Email', example: 'em@il.com' }),
+    gid: z.string().openapi({ example: exampleGid(false) }),
+    type: z.literal(AuditRecordType.USER).openapi({ title: 'User', example: AuditRecordType.USER }),
+  })
+  .openapi({
+    description: 'A user who performed the action',
+    ref: 'AuditRecordUser',
+  })
 
 type AuditRecordUser = Prettify<z.infer<typeof schemaAuditRecordUser>>
 


### PR DESCRIPTION
- Updated `generate-all-openapi-specs.ts` to include spec comparison before writing to file.
- Enhanced tests in `generate-all-openapi-specs.test.ts` to cover scenarios for changed and unchanged specs.
- Removed unused `generate-open-api-route-config.ts` and replaced it with `append-open-api-metadata.ts` for better route metadata handling.
- Modified `init.ts` and `init.test.ts` to accommodate async initialization of HTTP routes and OpenAPI specs generation.
- Updated resource routes to use the new metadata appending function.
- Improved OpenAPI documentation generation by including more detailed descriptions and examples in resource schemas.
- Cleaned up imports and organized code for better readability and maintainability.