### PR TITLE
feat(NATE-075): ✨ Add Remeda library and update OpenAPI metadata handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "pg-error-enum": "^1",
         "pino": "^9",
         "pino-pretty": "^13",
+        "remeda": "^2",
         "ulid": "^3",
         "zod": "^3",
         "zod-openapi": "^4"
@@ -8090,6 +8091,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/remeda": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.21.3.tgz",
+      "integrity": "sha512-XXrZdLA10oEOQhLLzEJEiFFSKi21REGAkHdImIb4rt/XXy8ORGXh5HCcpUOsElfPNDb+X6TA/+wkh+p2KffYmg==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.39.1"
       }
     },
     "node_modules/repeat-string": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
       "knip",
       "lefthook",
       "Monitorable",
+      "remeda",
       "transpiling",
       "unstub"
     ],
@@ -82,6 +83,7 @@
     "pg-error-enum": "^1",
     "pino": "^9",
     "pino-pretty": "^13",
+    "remeda": "^2",
     "ulid": "^3",
     "zod": "^3",
     "zod-openapi": "^4"

--- a/specs/v1/openapi.json
+++ b/specs/v1/openapi.json
@@ -115,70 +115,13 @@
                 ],
                 "description": "A resource entity",
                 "example": {
-                  "gid": "999.00000000-0000-0000-0000-000000000000",
-                  "name": "Jane Doe",
-                  "timeZone": "America/New_York",
-                  "createdAt": "1900-01-01T00:00:00.000Z",
                   "createdBy": {
                     "email": "em@il.com",
                     "gid": "999.00000000-0000-0000-0000-000000000000",
                     "type": "USER"
                   },
-                  "updatedAt": "1900-01-01T00:00:00.000Z",
-                  "updatedBy": {
-                    "system": "SYSTEM",
-                    "type": "SYSTEM"
-                  }
-                }
-              },
-              "components": {
-                "AuditRecordSystem": {
-                  "type": "object",
-                  "properties": {
-                    "system": {
-                      "type": "string",
-                      "description": "The system that performed the action",
-                      "example": "SYSTEM"
-                    },
-                    "type": {
-                      "type": "string",
-                      "const": "SYSTEM",
-                      "title": "System",
-                      "example": "SYSTEM"
-                    }
-                  },
-                  "required": [
-                    "system",
-                    "type"
-                  ],
-                  "description": "A system that performed the action"
-                },
-                "AuditRecordUser": {
-                  "type": "object",
-                  "properties": {
-                    "email": {
-                      "type": "string",
-                      "format": "email",
-                      "description": "The email of the user who performed the action",
-                      "title": "Email",
-                      "example": "em@il.com"
-                    },
-                    "gid": {
-                      "type": "string",
-                      "example": "999.00000000-0000-0000-0000-000000000000"
-                    },
-                    "type": {
-                      "type": "string",
-                      "const": "USER",
-                      "title": "User",
-                      "example": "USER"
-                    }
-                  },
-                  "required": [
-                    "gid",
-                    "type"
-                  ],
-                  "description": "A user who performed the action"
+                  "name": "Jane Doe",
+                  "timeZone": "America/New_York"
                 }
               }
             }
@@ -519,70 +462,12 @@
                 ],
                 "description": "A resource entity",
                 "example": {
-                  "gid": "999.00000000-0000-0000-0000-000000000000",
                   "name": "Jane Doe",
                   "timeZone": "America/New_York",
-                  "createdAt": "1900-01-01T00:00:00.000Z",
-                  "createdBy": {
-                    "email": "em@il.com",
-                    "gid": "999.00000000-0000-0000-0000-000000000000",
-                    "type": "USER"
-                  },
-                  "updatedAt": "1900-01-01T00:00:00.000Z",
                   "updatedBy": {
                     "system": "SYSTEM",
                     "type": "SYSTEM"
                   }
-                }
-              },
-              "components": {
-                "AuditRecordSystem": {
-                  "type": "object",
-                  "properties": {
-                    "system": {
-                      "type": "string",
-                      "description": "The system that performed the action",
-                      "example": "SYSTEM"
-                    },
-                    "type": {
-                      "type": "string",
-                      "const": "SYSTEM",
-                      "title": "System",
-                      "example": "SYSTEM"
-                    }
-                  },
-                  "required": [
-                    "system",
-                    "type"
-                  ],
-                  "description": "A system that performed the action"
-                },
-                "AuditRecordUser": {
-                  "type": "object",
-                  "properties": {
-                    "email": {
-                      "type": "string",
-                      "format": "email",
-                      "description": "The email of the user who performed the action",
-                      "title": "Email",
-                      "example": "em@il.com"
-                    },
-                    "gid": {
-                      "type": "string",
-                      "example": "999.00000000-0000-0000-0000-000000000000"
-                    },
-                    "type": {
-                      "type": "string",
-                      "const": "USER",
-                      "title": "User",
-                      "example": "USER"
-                    }
-                  },
-                  "required": [
-                    "gid",
-                    "type"
-                  ],
-                  "description": "A user who performed the action"
                 }
               }
             }

--- a/src/api/http/v1/openapi/append-open-api-metadata.test.ts
+++ b/src/api/http/v1/openapi/append-open-api-metadata.test.ts
@@ -40,7 +40,7 @@ describe('appendOpenApiMetadata', () => {
       type: RouteType.CREATE_ONE,
       operationId: 'EntityCreateOne',
       requestSchema,
-      schemaResponse: baseResponseSchema,
+      responseSchema: baseResponseSchema,
       tags: baseTags,
       // biome-ignore lint/suspicious/noExplicitAny: <explanation>
     }) as any
@@ -76,7 +76,7 @@ describe('appendOpenApiMetadata', () => {
     const result = appendOpenApiMetadata({
       type: RouteType.GET_ONE,
       operationId: 'EntityGetOne',
-      schemaResponse: baseResponseSchema,
+      responseSchema: baseResponseSchema,
       tags: baseTags,
       // biome-ignore lint/suspicious/noExplicitAny: <explanation>
     }) as any
@@ -101,7 +101,7 @@ describe('appendOpenApiMetadata', () => {
       filterableFields: ['name', 'age'],
       sortableFields: ['name', 'age'],
       requestSchema,
-      schemaResponse: baseResponseSchema,
+      responseSchema: baseResponseSchema,
       tags: baseTags,
       // biome-ignore lint/suspicious/noExplicitAny: <explanation>
     }) as any
@@ -125,7 +125,7 @@ describe('appendOpenApiMetadata', () => {
       type: RouteType.UPDATE_ONE,
       operationId: 'EntityUpdateOne',
       requestSchema,
-      schemaResponse: baseResponseSchema,
+      responseSchema: baseResponseSchema,
       tags: baseTags,
       // biome-ignore lint/suspicious/noExplicitAny: <explanation>
     }) as any
@@ -141,7 +141,7 @@ describe('appendOpenApiMetadata', () => {
       type: RouteType.GET_ONE,
       operationId: 'EntityGetOne',
       description: customDescription,
-      schemaResponse: baseResponseSchema,
+      responseSchema: baseResponseSchema,
       tags: baseTags,
       // biome-ignore lint/suspicious/noExplicitAny: <explanation>
     }) as any
@@ -168,7 +168,7 @@ describe('appendOpenApiMetadata', () => {
     const result = appendOpenApiMetadata({
       type: RouteType.GET_ONE,
       operationId: 'EntityGetOne',
-      schemaResponse: baseResponseSchema,
+      responseSchema: baseResponseSchema,
       tags: baseTags,
       // biome-ignore lint/suspicious/noExplicitAny: <explanation>
     }) as any
@@ -194,7 +194,7 @@ describe('appendOpenApiMetadata', () => {
         // biome-ignore lint/suspicious/noExplicitAny: <explanation>
         type: 'unknown' as any,
         operationId: 'EntityGetOne',
-        schemaResponse: baseResponseSchema,
+        responseSchema: baseResponseSchema,
         tags: baseTags,
       }),
     ).toThrow('Unhandled route type: unknown')
@@ -210,7 +210,7 @@ describe('appendOpenApiMetadata', () => {
       filterableFields: [],
       sortableFields: [],
       requestSchema,
-      schemaResponse: baseResponseSchema,
+      responseSchema: baseResponseSchema,
       tags: baseTags,
       // biome-ignore lint/suspicious/noExplicitAny: <explanation>
     }) as any

--- a/src/api/http/v1/openapi/append-open-api-metadata.ts
+++ b/src/api/http/v1/openapi/append-open-api-metadata.ts
@@ -50,14 +50,14 @@ const toResponse = (schemaResponse: AnyZodObject | undefined) => {
 type BaseRoute = {
   description?: string
   parameters?: unknown[]
-  schemaResponse?: AnyZodObject
+  responseSchema?: AnyZodObject
   tags: string[]
 }
 
 type CreateOneRoute = BaseRoute & {
   operationId: `${string}${'CreateOne'}`
   requestSchema: AnyZodObject
-  schemaResponse: AnyZodObject
+  responseSchema: AnyZodObject
   type: 'createOne'
 }
 
@@ -71,33 +71,33 @@ type GetManyRoute = BaseRoute & {
   filterableFields: string[]
   operationId: `${string}${'GetMany'}`
   requestSchema: AnyZodObject
-  schemaResponse: AnyZodObject
+  responseSchema: AnyZodObject
   sortableFields: string[]
   type: 'getMany'
 }
 
 type GetOneRoute = BaseRoute & {
   operationId: `${string}${'GetOne'}`
-  schemaResponse: AnyZodObject
+  responseSchema: AnyZodObject
   type: 'getOne'
 }
 
 type UpdateOneRoute = BaseRoute & {
   operationId: `${string}${'UpdateOne'}`
   requestSchema: AnyZodObject
-  schemaResponse: AnyZodObject
+  responseSchema: AnyZodObject
   type: 'updateOne'
 }
 
 type RouteConfig = CreateOneRoute | DeleteOneRoute | GetManyRoute | GetOneRoute | UpdateOneRoute
 
 const appendOpenApiMetadata = (config: RouteConfig) => {
-  const { description, operationId, schemaResponse, tags, type } = config
+  const { description, operationId, responseSchema, tags, type } = config
 
   let actualDescription: DescribeRouteOptions['description'] = description
   let actualParameters: DescribeRouteOptions['parameters'] = undefined
   let requestBody: DescribeRouteOptions['requestBody'] = undefined
-  let actualResponses: DescribeRouteOptions['responses'] = toResponse(schemaResponse)
+  let actualResponses: DescribeRouteOptions['responses'] = toResponse(responseSchema)
 
   switch (type) {
     case 'createOne': {
@@ -108,7 +108,10 @@ const appendOpenApiMetadata = (config: RouteConfig) => {
       requestBody = {
         required: true,
         content: {
-          'application/json': resolver(requestSchema).builder(),
+          'application/json': {
+            // @ts-expect-error Fix this type error
+            schema: resolver(requestSchema).builder().schema,
+          },
         },
       }
 
@@ -126,7 +129,7 @@ const appendOpenApiMetadata = (config: RouteConfig) => {
         },
       ]
 
-      actualResponses = toResponse(schemaResponse)
+      actualResponses = toResponse(undefined)
 
       break
     }
@@ -175,7 +178,10 @@ const appendOpenApiMetadata = (config: RouteConfig) => {
 
       requestBody = {
         content: {
-          'application/json': resolver(requestSchema).builder(),
+          'application/json': {
+            // @ts-expect-error Fix this type error
+            schema: resolver(requestSchema).builder().schema,
+          },
         },
       }
 

--- a/src/api/http/v1/routes/resources.ts
+++ b/src/api/http/v1/routes/resources.ts
@@ -14,7 +14,7 @@ resources.post(
   appendOpenApiMetadata({
     operationId: 'resourcesCreateOne',
     requestSchema: ResourceService.schemas.request.createOne,
-    schemaResponse: ResourceService.schemas.response.getOne,
+    responseSchema: ResourceService.schemas.response.getOne,
     tags: [OpenApiTag.RESOURCES],
     type: RouteType.CREATE_ONE,
   }),
@@ -34,7 +34,7 @@ resources.get(
     filterableFields: ResourceService.filterableFields,
     operationId: 'resourcesGetMany',
     requestSchema: ResourceService.schemas.request.getMany,
-    schemaResponse: ResourceService.schemas.response.getMany,
+    responseSchema: ResourceService.schemas.response.getMany,
     sortableFields: ResourceService.sortableFields,
     tags: [OpenApiTag.RESOURCES],
     type: RouteType.GET_MANY,
@@ -59,7 +59,7 @@ resources.get(
   '/:gid',
   appendOpenApiMetadata({
     operationId: 'resourcesGetOne',
-    schemaResponse: ResourceService.schemas.response.getOne,
+    responseSchema: ResourceService.schemas.response.getOne,
     tags: [OpenApiTag.RESOURCES],
     type: RouteType.GET_ONE,
   }),
@@ -77,7 +77,7 @@ resources.patch(
   appendOpenApiMetadata({
     operationId: 'resourcesUpdateOne',
     requestSchema: ResourceService.schemas.request.updateOne,
-    schemaResponse: ResourceService.schemas.response.getOne,
+    responseSchema: ResourceService.schemas.response.getOne,
     tags: [OpenApiTag.RESOURCES],
     type: RouteType.UPDATE_ONE,
   }),

--- a/src/domain/services/resource.ts
+++ b/src/domain/services/resource.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod'
 import { DomainNotFoundError } from '../../models/custom-error.ts'
+import { pick } from '../../utils/fp.ts'
 import { gid } from '../../utils/generators/gid.ts'
 import { toPaginatedResponseSchema } from '../models/pagination.ts'
 import { schemaDomainGetManyRequest } from '../models/request.ts'
@@ -16,11 +17,15 @@ class ResourceService {
   static schemas = {
     core: schemaResource,
     request: {
-      createOne: schemaResource.pick({
-        createdBy: true,
-        name: true,
-        timeZone: true,
-      }),
+      createOne: schemaResource
+        .pick({
+          createdBy: true,
+          name: true,
+          timeZone: true,
+        })
+        .openapi({
+          example: pick(exampleResource(), ['createdBy', 'name', 'timeZone']),
+        }),
       getMany: schemaResource,
       updateOne: schemaResource
         .pick({
@@ -28,9 +33,12 @@ class ResourceService {
           timeZone: true,
           updatedBy: true,
         })
-        .extend({
-          name: schemaResource.shape.name.optional(),
-          timeZone: schemaResource.shape.timeZone.optional(),
+        .partial({
+          name: true,
+          timeZone: true,
+        })
+        .openapi({
+          example: pick(exampleResource(), ['name', 'timeZone', 'updatedBy']),
         }),
     },
     response: {

--- a/src/utils/fp.ts
+++ b/src/utils/fp.ts
@@ -1,0 +1,2 @@
+// biome-ignore lint/performance/noBarrelFile: <explanation>
+export { pick } from 'remeda'


### PR DESCRIPTION
- Introduced the `remeda` library for enhanced functional programming utilities.
- Updated OpenAPI metadata configuration to replace `schemaResponse` with `responseSchema` for consistency across route definitions.
- Cleaned up OpenAPI examples and improved schema definitions in resource services.